### PR TITLE
Add plugin for app startup in pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,15 @@
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>0.0.4</version>
                 <configuration>
-                    <mainClass>org.app.App</mainClass>
+                    <mainClass>org.app.Launcher</mainClass>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.4.0</version>
+                <configuration>
+                    <mainClass>org.app.Launcher</mainClass>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Thanks to this plugin application can be started without specifying Launcher class explictly.